### PR TITLE
Fix `thow`

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1051,6 +1051,7 @@ function ValidateLayer(schema, root, argv){
 		validator.errors = root.errors;
 		validator.throw = root.throw;
 		validator.annotations = root.annotations;
+		validator.emitError = root.emitError;
 	}else{
 		validator.errors = [];
 		validator.throw = null;


### PR DESCRIPTION
With `throw: true` we are getting error (this patch fixes that):
```sh
TypeError: self.root.emitError is not a function
        at ValidateLayer.addErrorList (/Users/tino-afflu/Repos/cloud-data-sources-tf/node_modules/jsonschemaparse/lib/schema.js:1124:42)
        at ValidateLayer.startString (/Users/tino-afflu/Repos/cloud-data-sources-tf/node_modules/jsonschemaparse/lib/schema.js:1209:8)
        at /Users/tino-afflu/Repos/cloud-data-sources-tf/node_modules/jsonschemaparse/lib/parse.js:1236:46
        at /Users/tino-afflu/Repos/cloud-data-sources-tf/node_modules/jsonschemaparse/lib/parse.js:323:3
        at Array.forEach (<anonymous>)
        at StreamParser.validateInstance (/Users/tino-afflu/Repos/cloud-data-sources-tf/node_modules/jsonschemaparse/lib/parse.js:322:23)
        at StreamParser.startString (/Users/tino-afflu/Repos/cloud-data-sources-tf/node_modules/jsonschemaparse/lib/parse.js:1236:7)
        at StreamParser.parseBlock (/Users/tino-afflu/Repos/cloud-data-sources-tf/node_modules/jsonschemaparse/lib/parse.js:436:10)
        at StreamParser.Object.<anonymous>.StreamParser._transform.StreamParser._write (/Users/tino-afflu/Repos/cloud-data-sources-tf/node_modules/jsonschemaparse/lib/parse.js:329:8)
        at writeOrBuffer (node:internal/streams/writable:389:12)
```